### PR TITLE
accept trailing comma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,13 @@ macro_rules! assert_json_include {
             panic!("\n\n{}\n\n", error);
         }
     }};
+    (actual: $actual:expr, expected: $expected:expr,) => {{
+        $crate::assert_json_include!(actual: $actual, expected: $expected)
+    }};
     (expected: $expected:expr, actual: $actual:expr) => {{
+        $crate::assert_json_include!(actual: $actual, expected: $expected)
+    }};
+    (expected: $expected:expr, actual: $actual:expr,) => {{
         $crate::assert_json_include!(actual: $actual, expected: $expected)
     }};
 }
@@ -221,6 +227,9 @@ macro_rules! assert_json_eq {
         if let Err(error) = $crate::assert_json_no_panic(comparison) {
             panic!("\n\n{}\n\n", error);
         }
+    }};
+    ($lhs:expr, $rhs:expr,) => {{
+        $crate::assert_json_eq!($lhs, $rhs)
     }};
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,6 +14,16 @@ fn can_pass() {
         actual: json!({ "a": { "b": true } }),
         expected: json!({ "a": {} })
     );
+
+    assert_json_include!(
+        actual: json!({ "a": { "b": true } }),
+        expected: json!({ "a": {} }),
+    );
+
+    assert_json_include!(
+        expected: json!({ "a": {} }),
+        actual: json!({ "a": { "b": true } }),
+    );
 }
 
 #[test]
@@ -28,6 +38,7 @@ fn can_fail() {
 #[test]
 fn can_pass_with_exact_match() {
     assert_json_eq!(json!({ "a": { "b": true } }), json!({ "a": { "b": true } }));
+    assert_json_eq!(json!({ "a": { "b": true } }), json!({ "a": { "b": true } }),);
 }
 
 #[test]


### PR DESCRIPTION
Hi

I want to use it in the following writing style, I tried to allow the trailing comma


```rust
    assert_json_include! (
        actual: json! ({"a": {"b": true}}),
        expected: json! ({"a": {}}),
    );
```

What do you think?