### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2019 David Pedersen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Add MIT license file, with the beginning copyright
line filled in. Including a LICENSE file is useful for
packaging in Linux distributions, such as Fedora.

---

Reason for this: I would like to package and build the `assert-json-diff` crate in Fedora, needed in order to build an updated version of `mockito`(from version `0.17.1` to `0.20.0`) which utilizes `assert-json-diff`. The updated `mockito` version is ultimately needed to build [Zincati](https://github.com/coreos/zincati), the update agent for Fedora CoreOS.

The MIT license is copied from https://opensource.org/licenses/MIT, with `Copyright <YEAR> <COPYRIGHT HOLDER>` filled in  as `Copyright (c) 2018 David Pedersen`. Please feel free to modify this PR, or close and open a new one for any changes (I'm also happy to update this PR with changes). Would be much appreciated to have the LICENSE file added so the license can be included in the RPM package in Fedora.