### PR TITLE
Cargo.toml: Bump version-sync to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.32"
 serde = "1.0.80"
 
 [dev-dependencies]
-version-sync = "0.5"
+version-sync = "0.8"
 
 [badges]
 travis-ci = { repository = "davidpdrsn/assert-json-diff", branch = "master" }


### PR DESCRIPTION
Update version-sync requirement to the 0.8 minor version. According to the [release history](https://github.com/mgeisler/version-sync/blob/master/README.md#release-history) there does not appear to be breaking changes. Notably the Rust version is updated to the 2018 edition.

Context: Fedora currently includes the 0.8 version of `version-sync` - this patch is needed to build `assert-json-diff` in Fedora. Would like to upstream the patch here too.