### PR TITLE
Introduce non-panicing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- Introduce non-panicing functions with `assert_json_include_no_panic` and `assert_json_eq_no_panic`.
 
 ### Breaking changes
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,5 +1,4 @@
 use crate::core_ext::{Indent, Indexes};
-use crate::Mode;
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
@@ -7,6 +6,12 @@ pub fn diff<'a>(lhs: &'a Value, rhs: &'a Value, mode: Mode) -> Vec<Difference<'a
     let mut acc = vec![];
     diff_with(lhs, rhs, mode, Path::Root, &mut acc);
     acc
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Mode {
+    Lenient,
+    Strict,
 }
 
 fn diff_with<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ macro_rules! assert_json_include {
     (actual: $actual:expr, expected: $expected:expr) => {{
         let actual: serde_json::Value = $actual;
         let expected: serde_json::Value = $expected;
-        if let Err(error) = $crate::assert_json_include_no_panic(actual, expected) {
+        if let Err(error) = $crate::assert_json_include_no_panic(&actual, &expected) {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -209,9 +209,9 @@ macro_rules! assert_json_include {
 #[macro_export]
 macro_rules! assert_json_eq {
     ($lhs:expr, $rhs:expr) => {{
-        let actual: serde_json::Value = $lhs;
-        let expected: serde_json::Value = $rhs;
-        if let Err(error) = $crate::assert_json_eq_no_panic(actual, expected) {
+        let lhs: serde_json::Value = $lhs;
+        let rhs: serde_json::Value = $rhs;
+        if let Err(error) = $crate::assert_json_eq_no_panic(&lhs, &rhs) {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -225,7 +225,7 @@ macro_rules! assert_json_eq {
 /// Instead it returns a `Result` where the error is the message that would be passed to `panic!`.
 /// This is might be useful if you want to control how failures are reported and don't want to deal
 /// with panics.
-pub fn assert_json_include_no_panic(actual: Value, expected: Value) -> Result<(), String> {
+pub fn assert_json_include_no_panic(actual: &Value, expected: &Value) -> Result<(), String> {
     assert_json_no_panic(actual, expected, Mode::Lenient)
 }
 
@@ -234,12 +234,12 @@ pub fn assert_json_include_no_panic(actual: Value, expected: Value) -> Result<()
 /// Instead it returns a `Result` where the error is the message that would be passed to `panic!`.
 /// This is might be useful if you want to control how failures are reported and don't want to deal
 /// with panics.
-pub fn assert_json_eq_no_panic(lhs: Value, rhs: Value) -> Result<(), String> {
+pub fn assert_json_eq_no_panic(lhs: &Value, rhs: &Value) -> Result<(), String> {
     assert_json_no_panic(lhs, rhs, Mode::Strict)
 }
 
-fn assert_json_no_panic(lhs: Value, rhs: Value, mode: Mode) -> Result<(), String> {
-    let diffs = diff(&lhs, &rhs, mode);
+fn assert_json_no_panic(lhs: &Value, rhs: &Value, mode: Mode) -> Result<(), String> {
+    let diffs = diff(lhs, rhs, mode);
 
     if diffs.is_empty() {
         Ok(())
@@ -548,10 +548,10 @@ mod tests {
     }
 
     fn test_partial_match(lhs: Value, rhs: Value) -> Result<(), String> {
-        assert_json_no_panic(lhs, rhs, Mode::Lenient)
+        assert_json_no_panic(&lhs, &rhs, Mode::Lenient)
     }
 
     fn test_exact_match(lhs: Value, rhs: Value) -> Result<(), String> {
-        assert_json_no_panic(lhs, rhs, Mode::Strict)
+        assert_json_no_panic(&lhs, &rhs, Mode::Strict)
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,8 @@ extern crate assert_json_diff;
 #[macro_use]
 extern crate serde_json;
 
+use assert_json_diff::{assert_json_eq_no_panic, assert_json_include_no_panic};
+
 #[test]
 fn can_pass() {
     assert_json_include!(
@@ -45,4 +47,18 @@ fn can_pass_with_exact_match() {
 #[should_panic]
 fn can_fail_with_exact_match() {
     assert_json_eq!(json!({ "a": { "b": true } }), json!({ "a": {} }));
+}
+
+#[test]
+fn inclusive_match_without_panicing() {
+    assert!(assert_json_include_no_panic(json!({ "a": 1, "b": 2 }), json!({ "b": 2})).is_ok());
+
+    assert!(assert_json_include_no_panic(json!({ "a": 1, "b": 2 }), json!("foo")).is_err());
+}
+
+#[test]
+fn exact_match_without_panicing() {
+    assert!(assert_json_eq_no_panic(json!([1, 2, 3]), json!([1, 2, 3])).is_ok());
+
+    assert!(assert_json_eq_no_panic(json!([1, 2, 3]), json!("foo")).is_err());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -51,14 +51,14 @@ fn can_fail_with_exact_match() {
 
 #[test]
 fn inclusive_match_without_panicing() {
-    assert!(assert_json_include_no_panic(json!({ "a": 1, "b": 2 }), json!({ "b": 2})).is_ok());
+    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!({ "b": 2})).is_ok());
 
-    assert!(assert_json_include_no_panic(json!({ "a": 1, "b": 2 }), json!("foo")).is_err());
+    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!("foo")).is_err());
 }
 
 #[test]
 fn exact_match_without_panicing() {
-    assert!(assert_json_eq_no_panic(json!([1, 2, 3]), json!([1, 2, 3])).is_ok());
+    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3])).is_ok());
 
-    assert!(assert_json_eq_no_panic(json!([1, 2, 3]), json!("foo")).is_err());
+    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo")).is_err());
 }


### PR DESCRIPTION
This removes the previously `#[doc(hidden)]` `assert_json_no_panic` function and instead introduces

```rust
pub fn assert_json_include_no_panic(
    actual: Value,
    expected: Value
) -> Result<(), String> {}

pub fn assert_json_eq_no_panic(
    lhs: Value,
    rhs: Value
) -> Result<(), String> {}
```

These do the same that the macros do, but don't panic and instead return a `Result` which might contain the error message that would otherwise be passed to `panic!`.

I wouldn't consider this a breaking change, but obviously further changes to `assert_json_include_no_panic` and `assert_json_eq_no_panic` would be breaking.

@Diggsey @vldm Does this look good to you?

Fixes https://github.com/davidpdrsn/assert-json-diff/issues/10