### PR TITLE
feat: numeric mode for less strict type comparison

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
 use assert_json_diff::{
-    assert_json_eq, assert_json_eq_no_panic, assert_json_include, assert_json_include_no_panic,
+    assert_json_eq, assert_json_eq_no_panic, assert_json_include, assert_json_include_no_panic, assert_json_eq_assume_float, assert_json_include_assume_float, NumericMode
 };
+
 use serde_json::json;
 
 #[test]
@@ -37,6 +38,36 @@ fn can_fail() {
 }
 
 #[test]
+#[should_panic]
+fn different_numeric_types_include_should_fail() {
+    assert_json_include!(
+        actual: json!({ "a": { "b": true }, "c": 1 }),
+        expected: json!({ "a": { "b": true }, "c": 1.0 })
+    );
+}
+
+#[test]
+#[should_panic]
+fn different_numeric_types_eq_should_fail() {
+    assert_json_eq!(
+        json!({ "a": { "b": true }, "c": 1 }),
+        json!({ "a": { "b": true }, "c": 1.0 })
+    );
+}
+
+#[test]
+fn different_numeric_types_assume_float() {
+    let actual = json!({ "a": { "b": true }, "c": [true, null, 1] });
+    let expected = json!({ "a": { "b": true }, "c": [true, null, 1.0] });
+    assert_json_include_assume_float!(
+        actual: &actual,
+        expected: &expected
+    );
+
+    assert_json_eq_assume_float!(actual, expected)
+}
+
+#[test]
 fn can_pass_with_exact_match() {
     assert_json_eq!(json!({ "a": { "b": true } }), json!({ "a": { "b": true } }));
     assert_json_eq!(json!({ "a": { "b": true } }), json!({ "a": { "b": true } }),);
@@ -50,16 +81,16 @@ fn can_fail_with_exact_match() {
 
 #[test]
 fn inclusive_match_without_panicing() {
-    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!({ "b": 2})).is_ok());
+    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!({ "b": 2}), NumericMode::Strict).is_ok());
 
-    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!("foo")).is_err());
+    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!("foo"), NumericMode::Strict).is_err());
 }
 
 #[test]
 fn exact_match_without_panicing() {
-    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3])).is_ok());
+    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3]), NumericMode::Strict).is_ok());
 
-    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo")).is_err());
+    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo"), NumericMode::Strict).is_err());
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
New macros for less strict numeric comparisons.

I'm using assert-json-diff crate in a project where I'm using macros to generate a rather large amount of structures for parsing of certain data exchange format. Example JSON files I got from upstream and am using for testing quite often contain integer-presenting data for decimal data type, which leads to errors in parsing result tests.