### PR TITLE
Future proof API for configuring comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- A less strict numeric mode for comparisons is now supported. The `AssumeFloat` mode will make `1 == 1.0`. This mode can be set via `Config::numeric_mode`.
+- A panicking `assert_json_matches` macro has been added which takes a `Config`.
 
 ### Breaking changes
 
-None.
+- Some breaking changes have been made to support customizing how the JSON values are compared:
+    - `assert_json_eq_no_panic` and `assert_json_include_no_panic` have been replaced by `assert_json_matches_no_panic` which takes a `Config` that describes how the comparison should work.
+    - This setup will support adding further customizations without more breaking changes.
 
 ## [1.1.0] - 2020-07-12
 

--- a/README.md
+++ b/README.md
@@ -22,47 +22,45 @@ If you want to assert that one JSON value is "included" in another use
 use assert_json_diff::assert_json_include;
 use serde_json::json;
 
-fn main() {
-    let a = json!({
-        "data": {
-            "users": [
-                {
-                    "id": 1,
-                    "country": {
-                        "name": "Denmark"
-                    }
-                },
-                {
-                    "id": 24,
-                    "country": {
-                        "name": "Denmark"
-                    }
+let a = json!({
+    "data": {
+        "users": [
+            {
+                "id": 1,
+                "country": {
+                    "name": "Denmark"
                 }
-            ]
-        }
-    });
-
-    let b = json!({
-        "data": {
-            "users": [
-                {
-                    "id": 1,
-                    "country": {
-                        "name": "Sweden"
-                    }
-                },
-                {
-                    "id": 2,
-                    "country": {
-                        "name": "Denmark"
-                    }
+            },
+            {
+                "id": 24,
+                "country": {
+                    "name": "Denmark"
                 }
-            ]
-        }
-    });
+            }
+        ]
+    }
+});
 
-    assert_json_include!(actual: a, expected: b)
-}
+let b = json!({
+    "data": {
+        "users": [
+            {
+                "id": 1,
+                "country": {
+                    "name": "Sweden"
+                }
+            },
+            {
+                "id": 2,
+                "country": {
+                    "name": "Denmark"
+                }
+            }
+        ]
+    }
+});
+
+assert_json_include!(actual: a, expected: b)
 ```
 
 This will panic with the error message:
@@ -88,16 +86,14 @@ of the JSON without having to specify the whole thing. For example this test pas
 use assert_json_diff::assert_json_include;
 use serde_json::json;
 
-fn main() {
-    assert_json_include!(
-        actual: json!({
-            "a": { "b": 1 },
-        }),
-        expected: json!({
-            "a": {},
-        })
-    )
-}
+assert_json_include!(
+    actual: json!({
+        "a": { "b": 1 },
+    }),
+    expected: json!({
+        "a": {},
+    })
+)
 ```
 
 However `expected` cannot contain additional data so this test fails:
@@ -106,16 +102,14 @@ However `expected` cannot contain additional data so this test fails:
 use assert_json_diff::assert_json_include;
 use serde_json::json;
 
-fn main() {
-    assert_json_include!(
-        actual: json!({
-            "a": {},
-        }),
-        expected: json!({
-            "a": { "b": 1 },
-        })
-    )
-}
+assert_json_include!(
+    actual: json!({
+        "a": {},
+    }),
+    expected: json!({
+        "a": { "b": 1 },
+    })
+)
 ```
 
 That will print
@@ -132,12 +126,10 @@ If you want to ensure two JSON values are *exactly* the same, use [`assert_json_
 use assert_json_diff::assert_json_eq;
 use serde_json::json;
 
-fn main() {
-    assert_json_eq!(
-        json!({ "a": { "b": 1 } }),
-        json!({ "a": {} })
-    )
-}
+assert_json_eq!(
+    json!({ "a": { "b": 1 } }),
+    json!({ "a": {} })
+)
 ```
 
 This will panic with the error message:
@@ -145,5 +137,9 @@ This will panic with the error message:
 ```
 json atom at path ".a.b" is missing from lhs
 ```
+
+### Further customization
+
+You can use [`assert_json_matches`] to further customize the comparison.
 
 License: MIT

--- a/src/core_ext.rs
+++ b/src/core_ext.rs
@@ -1,6 +1,6 @@
 use extend::ext;
 
-#[ext(pub, name = Indent)]
+#[ext(pub(crate), name = Indent)]
 impl<T> T
 where
     T: ToString,
@@ -8,7 +8,7 @@ where
     fn indent(&self, level: u32) -> String {
         let mut indent = String::new();
         for _ in 0..level {
-            indent.push_str(" ");
+            indent.push(' ');
         }
 
         self.to_string()
@@ -19,7 +19,7 @@ where
     }
 }
 
-#[ext(pub, name = Indexes)]
+#[ext(pub(crate), name = Indexes)]
 impl<T> Vec<T> {
     fn indexes(&self) -> Vec<usize> {
         if self.is_empty() {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,30 +1,18 @@
 use crate::core_ext::{Indent, Indexes};
-use crate::NumericMode;
+use crate::{CompareMode, Config, NumericMode};
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
-pub(crate) fn diff<'a>(
-    lhs: &'a Value,
-    rhs: &'a Value,
-    mode: Mode,
-    num_mode: NumericMode,
-) -> Vec<Difference<'a>> {
+pub(crate) fn diff<'a>(lhs: &'a Value, rhs: &'a Value, config: Config) -> Vec<Difference<'a>> {
     let mut acc = vec![];
-    diff_with(lhs, rhs, mode, num_mode, Path::Root, &mut acc);
+    diff_with(lhs, rhs, config, Path::Root, &mut acc);
     acc
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) enum Mode {
-    Lenient,
-    Strict,
 }
 
 fn diff_with<'a>(
     lhs: &'a Value,
     rhs: &'a Value,
-    mode: Mode,
-    num_mode: NumericMode,
+    config: Config,
     path: Path<'a>,
     acc: &mut Vec<Difference<'a>>,
 ) {
@@ -32,8 +20,7 @@ fn diff_with<'a>(
         rhs,
         path,
         acc,
-        mode,
-        num_mode,
+        config,
     };
 
     fold_json(lhs, &mut folder);
@@ -44,8 +31,7 @@ struct DiffFolder<'a, 'b> {
     rhs: &'a Value,
     path: Path<'a>,
     acc: &'b mut Vec<Difference<'a>>,
-    mode: Mode,
-    num_mode: NumericMode,
+    config: Config,
 }
 
 macro_rules! direct_compare {
@@ -56,8 +42,7 @@ macro_rules! direct_compare {
                     lhs: Some(lhs),
                     rhs: Some(&self.rhs),
                     path: self.path.clone(),
-                    mode: self.mode,
-                    num_mode: self.num_mode,
+                    config: self.config.clone(),
                 });
             }
         }
@@ -70,7 +55,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
     direct_compare!(on_string);
 
     fn on_number(&mut self, lhs: &'a Value) {
-        let is_equal = match self.num_mode {
+        let is_equal = match self.config.numeric_mode {
             NumericMode::Strict => self.rhs == lhs,
             NumericMode::AssumeFloat => self.rhs.as_f64() == lhs.as_f64(),
         };
@@ -79,8 +64,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                 lhs: Some(lhs),
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
-                mode: self.mode,
-                num_mode: self.num_mode,
+                config: self.config.clone(),
             });
         }
     }
@@ -89,25 +73,24 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
         if let Some(rhs) = self.rhs.as_array() {
             let lhs = lhs.as_array().unwrap();
 
-            match self.mode {
-                Mode::Lenient => {
+            match self.config.compare_mode {
+                CompareMode::Inclusive => {
                     for (idx, rhs) in rhs.iter().enumerate() {
                         let path = self.path.append(Key::Idx(idx));
 
                         if let Some(lhs) = lhs.get(idx) {
-                            diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc)
+                            diff_with(lhs, rhs, self.config.clone(), path, self.acc)
                         } else {
                             self.acc.push(Difference {
                                 lhs: None,
                                 rhs: Some(&self.rhs),
                                 path,
-                                mode: self.mode,
-                                num_mode: self.num_mode,
+                                config: self.config.clone(),
                             });
                         }
                     }
                 }
-                Mode::Strict => {
+                CompareMode::Strict => {
                     let all_keys = rhs
                         .indexes()
                         .into_iter()
@@ -118,15 +101,14 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
 
                         match (lhs.get(key), rhs.get(key)) {
                             (Some(lhs), Some(rhs)) => {
-                                diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc);
+                                diff_with(lhs, rhs, self.config.clone(), path, self.acc);
                             }
                             (None, Some(rhs)) => {
                                 self.acc.push(Difference {
                                     lhs: None,
                                     rhs: Some(rhs),
                                     path,
-                                    mode: self.mode,
-                                    num_mode: self.num_mode,
+                                    config: self.config.clone(),
                                 });
                             }
                             (Some(lhs), None) => {
@@ -134,8 +116,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                                     lhs: Some(lhs),
                                     rhs: None,
                                     path,
-                                    mode: self.mode,
-                                    num_mode: self.num_mode,
+                                    config: self.config.clone(),
                                 });
                             }
                             (None, None) => {
@@ -150,8 +131,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                 lhs: Some(lhs),
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
-                mode: self.mode,
-                num_mode: self.num_mode,
+                config: self.config.clone(),
             });
         }
     }
@@ -160,40 +140,38 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
         if let Some(rhs) = self.rhs.as_object() {
             let lhs = lhs.as_object().unwrap();
 
-            match self.mode {
-                Mode::Lenient => {
+            match self.config.compare_mode {
+                CompareMode::Inclusive => {
                     for (key, rhs) in rhs.iter() {
                         let path = self.path.append(Key::Field(key));
 
                         if let Some(lhs) = lhs.get(key) {
-                            diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc)
+                            diff_with(lhs, rhs, self.config.clone(), path, self.acc)
                         } else {
                             self.acc.push(Difference {
                                 lhs: None,
                                 rhs: Some(&self.rhs),
                                 path,
-                                mode: self.mode,
-                                num_mode: self.num_mode,
+                                config: self.config.clone(),
                             });
                         }
                     }
                 }
-                Mode::Strict => {
+                CompareMode::Strict => {
                     let all_keys = rhs.keys().chain(lhs.keys()).collect::<HashSet<_>>();
                     for key in all_keys {
                         let path = self.path.append(Key::Field(key));
 
                         match (lhs.get(key), rhs.get(key)) {
                             (Some(lhs), Some(rhs)) => {
-                                diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc);
+                                diff_with(lhs, rhs, self.config.clone(), path, self.acc);
                             }
                             (None, Some(rhs)) => {
                                 self.acc.push(Difference {
                                     lhs: None,
                                     rhs: Some(rhs),
                                     path,
-                                    mode: self.mode,
-                                    num_mode: self.num_mode,
+                                    config: self.config.clone(),
                                 });
                             }
                             (Some(lhs), None) => {
@@ -201,8 +179,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                                     lhs: Some(lhs),
                                     rhs: None,
                                     path,
-                                    mode: self.mode,
-                                    num_mode: self.num_mode,
+                                    config: self.config.clone(),
                                 });
                             }
                             (None, None) => {
@@ -217,8 +194,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                 lhs: Some(lhs),
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
-                mode: self.mode,
-                num_mode: self.num_mode,
+                config: self.config.clone(),
             });
         }
     }
@@ -229,50 +205,47 @@ pub(crate) struct Difference<'a> {
     path: Path<'a>,
     lhs: Option<&'a Value>,
     rhs: Option<&'a Value>,
-    mode: Mode,
-    num_mode: NumericMode,
+    config: Config,
 }
 
 impl<'a> fmt::Display for Difference<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Mode::*;
-
         let json_to_string = |json: &Value| serde_json::to_string_pretty(json).unwrap();
 
-        match (&self.mode, &self.lhs, &self.rhs) {
-            (Lenient, Some(actual), Some(expected)) => {
+        match (&self.config.compare_mode, &self.lhs, &self.rhs) {
+            (CompareMode::Inclusive, Some(actual), Some(expected)) => {
                 writeln!(f, "json atoms at path \"{}\" are not equal:", self.path)?;
                 writeln!(f, "    expected:")?;
                 writeln!(f, "{}", json_to_string(expected).indent(8))?;
                 writeln!(f, "    actual:")?;
                 write!(f, "{}", json_to_string(actual).indent(8))?;
             }
-            (Lenient, None, Some(_expected)) => {
+            (CompareMode::Inclusive, None, Some(_expected)) => {
                 write!(
                     f,
                     "json atom at path \"{}\" is missing from actual",
                     self.path
                 )?;
             }
-            (Lenient, Some(_actual), None) => {
+            (CompareMode::Inclusive, Some(_actual), None) => {
                 unreachable!("stuff missing actual wont produce an error")
             }
-            (Lenient, None, None) => unreachable!("can't both be missing"),
+            (CompareMode::Inclusive, None, None) => unreachable!("can't both be missing"),
 
-            (Strict, Some(lhs), Some(rhs)) => {
+            (CompareMode::Strict, Some(lhs), Some(rhs)) => {
                 writeln!(f, "json atoms at path \"{}\" are not equal:", self.path)?;
                 writeln!(f, "    lhs:")?;
                 writeln!(f, "{}", json_to_string(lhs).indent(8))?;
                 writeln!(f, "    rhs:")?;
                 write!(f, "{}", json_to_string(rhs).indent(8))?;
             }
-            (Strict, None, Some(_)) => {
+            (CompareMode::Strict, None, Some(_)) => {
                 write!(f, "json atom at path \"{}\" is missing from lhs", self.path)?;
             }
-            (Strict, Some(_), None) => {
+            (CompareMode::Strict, Some(_), None) => {
                 write!(f, "json atom at path \"{}\" is missing from rhs", self.path)?;
             }
-            (Strict, None, None) => unreachable!("can't both be missing"),
+            (CompareMode::Strict, None, None) => unreachable!("can't both be missing"),
         }
 
         Ok(())
@@ -349,81 +322,84 @@ mod test {
         let diffs = diff(
             &json!(null),
             &json!(null),
-            Mode::Lenient,
-            NumericMode::Strict,
+            Config::new(CompareMode::Inclusive),
         );
         assert_eq!(diffs, vec![]);
 
         let diffs = diff(
             &json!(false),
             &json!(false),
-            Mode::Lenient,
-            NumericMode::Strict,
+            Config::new(CompareMode::Inclusive),
         );
         assert_eq!(diffs, vec![]);
 
         let diffs = diff(
             &json!(true),
             &json!(true),
-            Mode::Lenient,
-            NumericMode::Strict,
+            Config::new(CompareMode::Inclusive),
         );
         assert_eq!(diffs, vec![]);
 
         let diffs = diff(
             &json!(false),
             &json!(true),
-            Mode::Lenient,
-            NumericMode::Strict,
+            Config::new(CompareMode::Inclusive),
         );
         assert_eq!(diffs.len(), 1);
 
         let diffs = diff(
             &json!(true),
             &json!(false),
-            Mode::Lenient,
-            NumericMode::Strict,
+            Config::new(CompareMode::Inclusive),
         );
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1);
         let expected = json!(1);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!(2);
         let expected = json!(1);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1);
         let expected = json!(2);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1.0);
         let expected = json!(1.0);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!(1);
         let expected = json!(1.0);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1.0);
         let expected = json!(1);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1);
         let expected = json!(1.0);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::AssumeFloat);
+        let diffs = diff(
+            &actual,
+            &expected,
+            Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat),
+        );
         assert_eq!(diffs, vec![]);
 
         let actual = json!(1.0);
         let expected = json!(1);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::AssumeFloat);
+        let diffs = diff(
+            &actual,
+            &expected,
+            Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat),
+        );
         assert_eq!(diffs, vec![]);
     }
 
@@ -432,52 +408,52 @@ mod test {
         // empty
         let actual = json!([]);
         let expected = json!([]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!([1]);
         let expected = json!([]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 0);
 
         let actual = json!([]);
         let expected = json!([1]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         // eq
         let actual = json!([1]);
         let expected = json!([1]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         // actual longer
         let actual = json!([1, 2]);
         let expected = json!([1]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         // expected longer
         let actual = json!([1]);
         let expected = json!([1, 2]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         // eq length but different
         let actual = json!([1, 3]);
         let expected = json!([1, 2]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         // different types
         let actual = json!(1);
         let expected = json!([1]);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!([1]);
         let expected = json!(1);
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
     }
 
@@ -485,22 +461,22 @@ mod test {
     fn test_array_strict() {
         let actual = json!([]);
         let expected = json!([]);
-        let diffs = diff(&actual, &expected, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 0);
 
         let actual = json!([1, 2]);
         let expected = json!([1, 2]);
-        let diffs = diff(&actual, &expected, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 0);
 
         let actual = json!([1]);
         let expected = json!([1, 2]);
-        let diffs = diff(&actual, &expected, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!([1, 2]);
         let expected = json!([1]);
-        let diffs = diff(&actual, &expected, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 1);
     }
 
@@ -508,32 +484,32 @@ mod test {
     fn test_object() {
         let actual = json!({});
         let expected = json!({});
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!({ "a": 1 });
         let expected = json!({ "a": 1 });
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!({ "a": 1, "b": 123 });
         let expected = json!({ "a": 1 });
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
 
         let actual = json!({ "a": 1 });
         let expected = json!({ "b": 1 });
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!({ "a": 1 });
         let expected = json!({ "a": 2 });
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs.len(), 1);
 
         let actual = json!({ "a": { "b": true } });
         let expected = json!({ "a": {} });
-        let diffs = diff(&actual, &expected, Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(&actual, &expected, Config::new(CompareMode::Inclusive));
         assert_eq!(diffs, vec![]);
     }
 
@@ -541,16 +517,16 @@ mod test {
     fn test_object_strict() {
         let lhs = json!({});
         let rhs = json!({ "a": 1 });
-        let diffs = diff(&lhs, &rhs, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&lhs, &rhs, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 1);
 
         let lhs = json!({ "a": 1 });
         let rhs = json!({});
-        let diffs = diff(&lhs, &rhs, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&lhs, &rhs, Config::new(CompareMode::Strict));
         assert_eq!(diffs.len(), 1);
 
         let json = json!({ "a": 1 });
-        let diffs = diff(&json, &json, Mode::Strict, NumericMode::Strict);
+        let diffs = diff(&json, &json, Config::new(CompareMode::Strict));
         assert_eq!(diffs, vec![]);
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,8 +1,9 @@
 use crate::core_ext::{Indent, Indexes};
+use crate::NumericMode;
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
-pub fn diff<'a>(
+pub(crate) fn diff<'a>(
     lhs: &'a Value,
     rhs: &'a Value,
     mode: Mode,
@@ -14,18 +15,9 @@ pub fn diff<'a>(
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Mode {
+pub(crate) enum Mode {
     Lenient,
     Strict,
-}
-
-/// How should numbers be compared.
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum NumericMode {
-    /// Different numeric types aren't considered equal.
-    Strict,
-    /// All numeric types are converted to float before comparison.
-    AssumeFloat,
 }
 
 fn diff_with<'a>(
@@ -233,7 +225,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Difference<'a> {
+pub(crate) struct Difference<'a> {
     path: Path<'a>,
     lhs: Option<&'a Value>,
     rhs: Option<&'a Value>,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -72,7 +72,7 @@ macro_rules! direct_compare {
     };
 }
 
-impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
+impl<'a, 'b> DiffFolder<'a, 'b> {
     direct_compare!(on_null);
     direct_compare!(on_bool);
     direct_compare!(on_string);
@@ -335,7 +335,7 @@ impl<'a> fmt::Display for Key<'a> {
     }
 }
 
-fn fold_json<'a, F: Folder<'a>>(json: &'a Value, folder: &mut F) {
+fn fold_json<'a>(json: &'a Value, folder: &mut DiffFolder<'a, '_>) {
     match json {
         Value::Null => folder.on_null(json),
         Value::Bool(_) => folder.on_bool(json),
@@ -344,21 +344,6 @@ fn fold_json<'a, F: Folder<'a>>(json: &'a Value, folder: &mut F) {
         Value::Array(_) => folder.on_array(json),
         Value::Object(_) => folder.on_object(json),
     }
-}
-
-#[allow(unused_variables)]
-trait Folder<'a> {
-    fn on_null(&mut self, json: &'a Value) {}
-
-    fn on_bool(&mut self, bool_json: &'a Value) {}
-
-    fn on_string(&mut self, str_json: &'a Value) {}
-
-    fn on_number(&mut self, number_json: &'a Value) {}
-
-    fn on_array(&mut self, array_json: &'a Value) {}
-
-    fn on_object(&mut self, obj_json: &'a Value) {}
 }
 
 #[cfg(test)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,7 +2,12 @@ use crate::core_ext::{Indent, Indexes};
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
-pub fn diff<'a>(lhs: &'a Value, rhs: &'a Value, mode: Mode, num_mode: NumericMode) -> Vec<Difference<'a>> {
+pub fn diff<'a>(
+    lhs: &'a Value,
+    rhs: &'a Value,
+    mode: Mode,
+    num_mode: NumericMode,
+) -> Vec<Difference<'a>> {
     let mut acc = vec![];
     diff_with(lhs, rhs, mode, num_mode, Path::Root, &mut acc);
     acc
@@ -13,7 +18,6 @@ pub enum Mode {
     Lenient,
     Strict,
 }
-
 
 /// How should numbers be compared.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -37,7 +41,7 @@ fn diff_with<'a>(
         path,
         acc,
         mode,
-        num_mode
+        num_mode,
     };
 
     fold_json(lhs, &mut folder);
@@ -49,7 +53,7 @@ struct DiffFolder<'a, 'b> {
     path: Path<'a>,
     acc: &'b mut Vec<Difference<'a>>,
     mode: Mode,
-    num_mode: NumericMode
+    num_mode: NumericMode,
 }
 
 macro_rules! direct_compare {
@@ -61,7 +65,7 @@ macro_rules! direct_compare {
                     rhs: Some(&self.rhs),
                     path: self.path.clone(),
                     mode: self.mode,
-                    num_mode: self.num_mode
+                    num_mode: self.num_mode,
                 });
             }
         }
@@ -76,7 +80,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
     fn on_number(&mut self, lhs: &'a Value) {
         let is_equal = match self.num_mode {
             NumericMode::Strict => self.rhs == lhs,
-            NumericMode::AssumeFloat => self.rhs.as_f64() == lhs.as_f64()
+            NumericMode::AssumeFloat => self.rhs.as_f64() == lhs.as_f64(),
         };
         if !is_equal {
             self.acc.push(Difference {
@@ -84,7 +88,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
                 mode: self.mode,
-                num_mode: self.num_mode
+                num_mode: self.num_mode,
             });
         }
     }
@@ -106,7 +110,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                 rhs: Some(&self.rhs),
                                 path,
                                 mode: self.mode,
-                                num_mode: self.num_mode
+                                num_mode: self.num_mode,
                             });
                         }
                     }
@@ -122,7 +126,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
 
                         match (lhs.get(key), rhs.get(key)) {
                             (Some(lhs), Some(rhs)) => {
-                                diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc );
+                                diff_with(lhs, rhs, self.mode, self.num_mode, path, self.acc);
                             }
                             (None, Some(rhs)) => {
                                 self.acc.push(Difference {
@@ -130,7 +134,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                     rhs: Some(rhs),
                                     path,
                                     mode: self.mode,
-                                    num_mode: self.num_mode
+                                    num_mode: self.num_mode,
                                 });
                             }
                             (Some(lhs), None) => {
@@ -139,7 +143,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                     rhs: None,
                                     path,
                                     mode: self.mode,
-                                    num_mode: self.num_mode
+                                    num_mode: self.num_mode,
                                 });
                             }
                             (None, None) => {
@@ -155,7 +159,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
                 mode: self.mode,
-                num_mode: self.num_mode
+                num_mode: self.num_mode,
             });
         }
     }
@@ -177,7 +181,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                 rhs: Some(&self.rhs),
                                 path,
                                 mode: self.mode,
-                                num_mode: self.num_mode
+                                num_mode: self.num_mode,
                             });
                         }
                     }
@@ -197,7 +201,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                     rhs: Some(rhs),
                                     path,
                                     mode: self.mode,
-                                    num_mode: self.num_mode
+                                    num_mode: self.num_mode,
                                 });
                             }
                             (Some(lhs), None) => {
@@ -206,7 +210,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                                     rhs: None,
                                     path,
                                     mode: self.mode,
-                                    num_mode: self.num_mode
+                                    num_mode: self.num_mode,
                                 });
                             }
                             (None, None) => {
@@ -222,7 +226,7 @@ impl<'a, 'b> Folder<'a> for DiffFolder<'a, 'b> {
                 rhs: Some(&self.rhs),
                 path: self.path.clone(),
                 mode: self.mode,
-                num_mode: self.num_mode
+                num_mode: self.num_mode,
             });
         }
     }
@@ -234,7 +238,7 @@ pub struct Difference<'a> {
     lhs: Option<&'a Value>,
     rhs: Option<&'a Value>,
     mode: Mode,
-    num_mode: NumericMode
+    num_mode: NumericMode,
 }
 
 impl<'a> fmt::Display for Difference<'a> {
@@ -365,19 +369,44 @@ mod test {
 
     #[test]
     fn test_diffing_leaf_json() {
-        let diffs = diff(&json!(null), &json!(null), Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(
+            &json!(null),
+            &json!(null),
+            Mode::Lenient,
+            NumericMode::Strict,
+        );
         assert_eq!(diffs, vec![]);
 
-        let diffs = diff(&json!(false), &json!(false), Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(
+            &json!(false),
+            &json!(false),
+            Mode::Lenient,
+            NumericMode::Strict,
+        );
         assert_eq!(diffs, vec![]);
 
-        let diffs = diff(&json!(true), &json!(true), Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(
+            &json!(true),
+            &json!(true),
+            Mode::Lenient,
+            NumericMode::Strict,
+        );
         assert_eq!(diffs, vec![]);
 
-        let diffs = diff(&json!(false), &json!(true), Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(
+            &json!(false),
+            &json!(true),
+            Mode::Lenient,
+            NumericMode::Strict,
+        );
         assert_eq!(diffs.len(), 1);
 
-        let diffs = diff(&json!(true), &json!(false), Mode::Lenient, NumericMode::Strict);
+        let diffs = diff(
+            &json!(true),
+            &json!(false),
+            Mode::Lenient,
+            NumericMode::Strict,
+        );
         assert_eq!(diffs.len(), 1);
 
         let actual = json!(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,47 +18,45 @@
 //! use assert_json_diff::assert_json_include;
 //! use serde_json::json;
 //!
-//! fn main() {
-//!     let a = json!({
-//!         "data": {
-//!             "users": [
-//!                 {
-//!                     "id": 1,
-//!                     "country": {
-//!                         "name": "Denmark"
-//!                     }
-//!                 },
-//!                 {
-//!                     "id": 24,
-//!                     "country": {
-//!                         "name": "Denmark"
-//!                     }
+//! let a = json!({
+//!     "data": {
+//!         "users": [
+//!             {
+//!                 "id": 1,
+//!                 "country": {
+//!                     "name": "Denmark"
 //!                 }
-//!             ]
-//!         }
-//!     });
-//!
-//!     let b = json!({
-//!         "data": {
-//!             "users": [
-//!                 {
-//!                     "id": 1,
-//!                     "country": {
-//!                         "name": "Sweden"
-//!                     }
-//!                 },
-//!                 {
-//!                     "id": 2,
-//!                     "country": {
-//!                         "name": "Denmark"
-//!                     }
+//!             },
+//!             {
+//!                 "id": 24,
+//!                 "country": {
+//!                     "name": "Denmark"
 //!                 }
-//!             ]
-//!         }
-//!     });
+//!             }
+//!         ]
+//!     }
+//! });
 //!
-//!     assert_json_include!(actual: a, expected: b)
-//! }
+//! let b = json!({
+//!     "data": {
+//!         "users": [
+//!             {
+//!                 "id": 1,
+//!                 "country": {
+//!                     "name": "Sweden"
+//!                 }
+//!             },
+//!             {
+//!                 "id": 2,
+//!                 "country": {
+//!                     "name": "Denmark"
+//!                 }
+//!             }
+//!         ]
+//!     }
+//! });
+//!
+//! assert_json_include!(actual: a, expected: b)
 //! ```
 //!
 //! This will panic with the error message:
@@ -84,16 +82,14 @@
 //! use assert_json_diff::assert_json_include;
 //! use serde_json::json;
 //!
-//! fn main() {
-//!     assert_json_include!(
-//!         actual: json!({
-//!             "a": { "b": 1 },
-//!         }),
-//!         expected: json!({
-//!             "a": {},
-//!         })
-//!     )
-//! }
+//! assert_json_include!(
+//!     actual: json!({
+//!         "a": { "b": 1 },
+//!     }),
+//!     expected: json!({
+//!         "a": {},
+//!     })
+//! )
 //! ```
 //!
 //! However `expected` cannot contain additional data so this test fails:
@@ -102,16 +98,14 @@
 //! use assert_json_diff::assert_json_include;
 //! use serde_json::json;
 //!
-//! fn main() {
-//!     assert_json_include!(
-//!         actual: json!({
-//!             "a": {},
-//!         }),
-//!         expected: json!({
-//!             "a": { "b": 1 },
-//!         })
-//!     )
-//! }
+//! assert_json_include!(
+//!     actual: json!({
+//!         "a": {},
+//!     }),
+//!     expected: json!({
+//!         "a": { "b": 1 },
+//!     })
+//! )
 //! ```
 //!
 //! That will print
@@ -128,12 +122,10 @@
 //! use assert_json_diff::assert_json_eq;
 //! use serde_json::json;
 //!
-//! fn main() {
-//!     assert_json_eq!(
-//!         json!({ "a": { "b": 1 } }),
-//!         json!({ "a": {} })
-//!     )
-//! }
+//! assert_json_eq!(
+//!     json!({ "a": { "b": 1 } }),
+//!     json!({ "a": {} })
+//! )
 //! ```
 //!
 //! This will panic with the error message:
@@ -141,29 +133,33 @@
 //! ```text
 //! json atom at path ".a.b" is missing from lhs
 //! ```
+//!
+//! ## Further customization
+//!
+//! You can use [`assert_json_matches`] to further customize the comparison.
 
-#![deny(
-    missing_docs,
-    unused_imports,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications,
-    unknown_lints
-)]
-#![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
+// #![deny(
+//     missing_docs,
+//     unused_imports,
+//     missing_debug_implementations,
+//     missing_copy_implementations,
+//     trivial_casts,
+//     trivial_numeric_casts,
+//     unsafe_code,
+//     unstable_features,
+//     unused_import_braces,
+//     unused_qualifications,
+//     unknown_lints
+// )]
+// #![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
 
-use diff::{diff, Mode};
+use diff::diff;
 use serde::Serialize;
 
 mod core_ext;
 mod diff;
 
-/// The macro used to compare two JSON values for an inclusive match.
+/// Compare two JSON values for an inclusive match.
 ///
 /// It allows `actual` to contain additional data. If you want an exact match use
 /// [`assert_json_eq`](macro.assert_json_eq.html) instead.
@@ -171,136 +167,73 @@ mod diff;
 /// See [crate documentation](index.html) for examples.
 #[macro_export]
 macro_rules! assert_json_include {
-    (actual: $actual:expr, expected: $expected:expr) => {{
-        let actual = $actual;
-        let expected = $expected;
-        if let Err(error) =
-            $crate::assert_json_include_no_panic(&actual, &expected, $crate::NumericMode::Strict)
-        {
-            panic!("\n\n{}\n\n", error);
-        }
+    (actual: $actual:expr, expected: $expected:expr $(,)?) => {{
+        $crate::assert_json_matches!(
+            $actual,
+            $expected,
+            $crate::Config::new($crate::CompareMode::Inclusive)
+        )
     }};
-    (actual: $actual:expr, expected: $expected:expr,) => {{
-        $crate::assert_json_include!(actual: $actual, expected: $expected)
-    }};
-    (expected: $expected:expr, actual: $actual:expr) => {{
-        $crate::assert_json_include!(actual: $actual, expected: $expected)
-    }};
-    (expected: $expected:expr, actual: $actual:expr,) => {{
+    (expected: $expected:expr, actual: $actual:expr $(,)?) => {{
         $crate::assert_json_include!(actual: $actual, expected: $expected)
     }};
 }
 
-/// The macro used to compare two JSON values for an inclusive match. Assumes that all numeric values are floats.
-///
-/// It allows `actual` to contain additional data. If you want an exact match use
-/// [`assert_json_eq`](macro.assert_json_eq.html) instead.
-///
-/// See [crate documentation](index.html) for examples.
-#[macro_export]
-macro_rules! assert_json_include_assume_float {
-    (actual: $actual:expr, expected: $expected:expr) => {{
-        let actual = $actual;
-        let expected = $expected;
-        if let Err(error) = $crate::assert_json_include_no_panic(
-            &actual,
-            &expected,
-            $crate::NumericMode::AssumeFloat,
-        ) {
-            panic!("\n\n{}\n\n", error);
-        }
-    }};
-    (actual: $actual:expr, expected: $expected:expr,) => {{
-        $crate::assert_json_include_assume_float!(actual: $actual, expected: $expected)
-    }};
-    (expected: $expected:expr, actual: $actual:expr) => {{
-        $crate::assert_json_include_assume_float!(actual: $actual, expected: $expected)
-    }};
-    (expected: $expected:expr, actual: $actual:expr,) => {{
-        $crate::assert_json_include_assume_float!(actual: $actual, expected: $expected)
-    }};
-}
-
-/// The macro used to compare two JSON values for an exact match.
+/// Compare two JSON values for an exact match.
 ///
 /// If you want an inclusive match use [`assert_json_include`](macro.assert_json_include.html) instead.
 ///
 /// See [crate documentation](index.html) for examples.
 #[macro_export]
 macro_rules! assert_json_eq {
-    ($lhs:expr, $rhs:expr) => {{
-        let lhs = $lhs;
-        let rhs = $rhs;
-        if let Err(error) = $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::Strict)
-        {
-            panic!("\n\n{}\n\n", error);
-        }
-    }};
-    ($lhs:expr, $rhs:expr,) => {{
-        $crate::assert_json_eq!($lhs, $rhs)
+    ($lhs:expr, $rhs:expr $(,)?) => {{
+        $crate::assert_json_matches!($lhs, $rhs, $crate::Config::new($crate::CompareMode::Strict))
     }};
 }
 
-/// The macro used to compare two JSON values for an exact match. Assume that all numeric values are float.
+/// Compare two JSON values according to a configuration.
 ///
-/// If you want an inclusive match use [`assert_json_include`](macro.assert_json_include.html) instead.
+/// ```
+/// use assert_json_diff::{
+///     CompareMode,
+///     Config,
+///     NumericMode,
+///     assert_json_matches,
+/// };
+/// use serde_json::json;
 ///
-/// See [crate documentation](index.html) for examples.
+/// let config = Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat);
+///
+/// assert_json_matches!(
+///     json!({
+///         "a": { "b": 1 },
+///     }),
+///     json!({
+///         "a": {},
+///     }),
+///     config,
+/// )
+/// ```
 #[macro_export]
-macro_rules! assert_json_eq_assume_float {
-    ($lhs:expr, $rhs:expr) => {{
+macro_rules! assert_json_matches {
+    ($lhs:expr, $rhs:expr, $config:expr $(,)?) => {{
         let lhs = $lhs;
         let rhs = $rhs;
-        if let Err(error) =
-            $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::AssumeFloat)
-        {
+        if let Err(error) = $crate::assert_json_matches_no_panic(&lhs, &rhs, $config) {
             panic!("\n\n{}\n\n", error);
         }
     }};
-    ($lhs:expr, $rhs:expr,) => {{
-        $crate::assert_json_eq!($lhs, $rhs)
-    }};
 }
 
-/// Does the same as [`assert_json_include!`](macro.assert_json_include.html) but doesn't panic.
+/// Compares two JSON values without panicking.
 ///
 /// Instead it returns a `Result` where the error is the message that would be passed to `panic!`.
 /// This is might be useful if you want to control how failures are reported and don't want to deal
 /// with panics.
-pub fn assert_json_include_no_panic<Actual, Expected>(
-    actual: &Actual,
-    expected: &Expected,
-    num_mode: NumericMode,
-) -> Result<(), String>
-where
-    Actual: Serialize,
-    Expected: Serialize,
-{
-    assert_json_no_panic(actual, expected, Mode::Lenient, num_mode)
-}
-
-/// Does the same as [`assert_json_eq!`](macro.assert_json_eq.html) but doesn't panic.
-///
-/// Instead it returns a `Result` where the error is the message that would be passed to `panic!`.
-/// This is might be useful if you want to control how failures are reported and don't want to deal
-/// with panics.
-pub fn assert_json_eq_no_panic<Lhs, Rhs>(
+pub fn assert_json_matches_no_panic<Lhs, Rhs>(
     lhs: &Lhs,
     rhs: &Rhs,
-    num_mode: NumericMode,
-) -> Result<(), String>
-where
-    Lhs: Serialize,
-    Rhs: Serialize,
-{
-    assert_json_no_panic(lhs, rhs, Mode::Strict, num_mode)
-}
-
-fn assert_json_no_panic<Lhs, Rhs>(
-    lhs: &Lhs,
-    rhs: &Rhs,
-    mode: Mode,
-    num_mode: NumericMode,
+    config: Config,
 ) -> Result<(), String>
 where
     Lhs: Serialize,
@@ -319,7 +252,7 @@ where
         )
     });
 
-    let diffs = diff(&lhs, &rhs, mode, num_mode);
+    let diffs = diff(&lhs, &rhs, config);
 
     if diffs.is_empty() {
         Ok(())
@@ -331,6 +264,55 @@ where
             .join("\n\n");
         Err(msg)
     }
+}
+
+/// Configuration for how JSON values should be compared.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(missing_copy_implementations)]
+pub struct Config {
+    pub(crate) compare_mode: CompareMode,
+    pub(crate) numeric_mode: NumericMode,
+}
+
+impl Config {
+    /// Create a new [`Config`] using the given [`CompareMode`].
+    ///
+    /// The default `numeric_mode` is be [`NumericMode::Strict`].
+    pub fn new(compare_mode: CompareMode) -> Self {
+        Self {
+            compare_mode,
+            numeric_mode: NumericMode::Strict,
+        }
+    }
+
+    /// Change the config's numeric mode.
+    ///
+    /// The default `numeric_mode` is be [`NumericMode::Strict`].
+    pub fn numeric_mode(mut self, numeric_mode: NumericMode) -> Self {
+        self.numeric_mode = numeric_mode;
+        self
+    }
+
+    /// Change the config's compare mode.
+    pub fn compare_mode(mut self, compare_mode: CompareMode) -> Self {
+        self.compare_mode = compare_mode;
+        self
+    }
+}
+
+/// Mode for how JSON values should be compared.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum CompareMode {
+    /// The two JSON values don't have to be exactly equal. The "actual" value must is only
+    /// required to be "contained" inside "expected". See [crate documentation](index.html) for
+    /// examples.
+    ///
+    /// The mode used with [`assert_json_include`].
+    Inclusive,
+    /// The two JSON values must be exactly equal.
+    ///
+    /// The mode used with [`assert_json_eq`].
+    Strict,
 }
 
 /// How should numbers be compared.
@@ -638,10 +620,10 @@ mod tests {
     }
 
     fn test_partial_match(lhs: Value, rhs: Value) -> Result<(), String> {
-        assert_json_no_panic(&lhs, &rhs, Mode::Lenient, NumericMode::Strict)
+        assert_json_matches_no_panic(&lhs, &rhs, Config::new(CompareMode::Inclusive))
     }
 
     fn test_exact_match(lhs: Value, rhs: Value) -> Result<(), String> {
-        assert_json_no_panic(&lhs, &rhs, Mode::Strict, NumericMode::Strict)
+        assert_json_matches_no_panic(&lhs, &rhs, Config::new(CompareMode::Strict))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,9 @@
 )]
 #![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
 
+pub use crate::diff::NumericMode;
 use diff::{diff, Mode};
 use serde::Serialize;
-pub use crate::diff::NumericMode;
 
 mod core_ext;
 mod diff;
@@ -175,7 +175,9 @@ macro_rules! assert_json_include {
     (actual: $actual:expr, expected: $expected:expr) => {{
         let actual = $actual;
         let expected = $expected;
-        if let Err(error) = $crate::assert_json_include_no_panic(&actual, &expected, $crate::NumericMode::Strict) {
+        if let Err(error) =
+            $crate::assert_json_include_no_panic(&actual, &expected, $crate::NumericMode::Strict)
+        {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -201,7 +203,11 @@ macro_rules! assert_json_include_assume_float {
     (actual: $actual:expr, expected: $expected:expr) => {{
         let actual = $actual;
         let expected = $expected;
-        if let Err(error) = $crate::assert_json_include_no_panic(&actual, &expected, $crate::NumericMode::AssumeFloat) {
+        if let Err(error) = $crate::assert_json_include_no_panic(
+            &actual,
+            &expected,
+            $crate::NumericMode::AssumeFloat,
+        ) {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -226,7 +232,8 @@ macro_rules! assert_json_eq {
     ($lhs:expr, $rhs:expr) => {{
         let lhs = $lhs;
         let rhs = $rhs;
-        if let Err(error) = $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::Strict) {
+        if let Err(error) = $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::Strict)
+        {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -245,7 +252,9 @@ macro_rules! assert_json_eq_assume_float {
     ($lhs:expr, $rhs:expr) => {{
         let lhs = $lhs;
         let rhs = $rhs;
-        if let Err(error) = $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::AssumeFloat) {
+        if let Err(error) =
+            $crate::assert_json_eq_no_panic(&lhs, &rhs, $crate::NumericMode::AssumeFloat)
+        {
             panic!("\n\n{}\n\n", error);
         }
     }};
@@ -262,7 +271,7 @@ macro_rules! assert_json_eq_assume_float {
 pub fn assert_json_include_no_panic<Actual, Expected>(
     actual: &Actual,
     expected: &Expected,
-    num_mode: NumericMode
+    num_mode: NumericMode,
 ) -> Result<(), String>
 where
     Actual: Serialize,
@@ -276,7 +285,11 @@ where
 /// Instead it returns a `Result` where the error is the message that would be passed to `panic!`.
 /// This is might be useful if you want to control how failures are reported and don't want to deal
 /// with panics.
-pub fn assert_json_eq_no_panic<Lhs, Rhs>(lhs: &Lhs, rhs: &Rhs, num_mode: NumericMode) -> Result<(), String>
+pub fn assert_json_eq_no_panic<Lhs, Rhs>(
+    lhs: &Lhs,
+    rhs: &Rhs,
+    num_mode: NumericMode,
+) -> Result<(), String>
 where
     Lhs: Serialize,
     Rhs: Serialize,
@@ -284,7 +297,12 @@ where
     assert_json_no_panic(lhs, rhs, Mode::Strict, num_mode)
 }
 
-fn assert_json_no_panic<Lhs, Rhs>(lhs: &Lhs, rhs: &Rhs, mode: Mode, num_mode: NumericMode) -> Result<(), String>
+fn assert_json_no_panic<Lhs, Rhs>(
+    lhs: &Lhs,
+    rhs: &Rhs,
+    mode: Mode,
+    num_mode: NumericMode,
+) -> Result<(), String>
 where
     Lhs: Serialize,
     Rhs: Serialize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,20 +138,20 @@
 //!
 //! You can use [`assert_json_matches`] to further customize the comparison.
 
-// #![deny(
-//     missing_docs,
-//     unused_imports,
-//     missing_debug_implementations,
-//     missing_copy_implementations,
-//     trivial_casts,
-//     trivial_numeric_casts,
-//     unsafe_code,
-//     unstable_features,
-//     unused_import_braces,
-//     unused_qualifications,
-//     unknown_lints
-// )]
-// #![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
+#![deny(
+    missing_docs,
+    unused_imports,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications,
+    unknown_lints
+)]
+#![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
 
 use diff::diff;
 use serde::Serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,6 @@
 )]
 #![doc(html_root_url = "https://docs.rs/assert-json-diff/1.1.0")]
 
-pub use crate::diff::NumericMode;
 use diff::{diff, Mode};
 use serde::Serialize;
 
@@ -332,6 +331,15 @@ where
             .join("\n\n");
         Err(msg)
     }
+}
+
+/// How should numbers be compared.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum NumericMode {
+    /// Different numeric types aren't considered equal.
+    Strict,
+    /// All numeric types are converted to float before comparison.
+    AssumeFloat,
 }
 
 #[cfg(test)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,8 @@
-use serde::Serialize;
 use assert_json_diff::{
-    assert_json_eq, assert_json_eq_no_panic, assert_json_include, assert_json_include_no_panic, assert_json_eq_assume_float, assert_json_include_assume_float, NumericMode
+    assert_json_eq, assert_json_eq_assume_float, assert_json_eq_no_panic, assert_json_include,
+    assert_json_include_assume_float, assert_json_include_no_panic, NumericMode,
 };
+use serde::Serialize;
 
 use serde_json::json;
 
@@ -59,10 +60,7 @@ fn different_numeric_types_eq_should_fail() {
 fn different_numeric_types_assume_float() {
     let actual = json!({ "a": { "b": true }, "c": [true, null, 1] });
     let expected = json!({ "a": { "b": true }, "c": [true, null, 1.0] });
-    assert_json_include_assume_float!(
-        actual: &actual,
-        expected: &expected
-    );
+    assert_json_include_assume_float!(actual: &actual, expected: &expected);
 
     assert_json_eq_assume_float!(actual, expected)
 }
@@ -81,22 +79,36 @@ fn can_fail_with_exact_match() {
 
 #[test]
 fn inclusive_match_without_panicing() {
-    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!({ "b": 2}), NumericMode::Strict).is_ok());
+    assert!(assert_json_include_no_panic(
+        &json!({ "a": 1, "b": 2 }),
+        &json!({ "b": 2}),
+        NumericMode::Strict
+    )
+    .is_ok());
 
-    assert!(assert_json_include_no_panic(&json!({ "a": 1, "b": 2 }), &json!("foo"), NumericMode::Strict).is_err());
+    assert!(assert_json_include_no_panic(
+        &json!({ "a": 1, "b": 2 }),
+        &json!("foo"),
+        NumericMode::Strict
+    )
+    .is_err());
 }
 
 #[test]
 fn exact_match_without_panicing() {
-    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3]), NumericMode::Strict).is_ok());
+    assert!(
+        assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3]), NumericMode::Strict).is_ok()
+    );
 
-    assert!(assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo"), NumericMode::Strict).is_err());
+    assert!(
+        assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo"), NumericMode::Strict).is_err()
+    );
 }
 
 #[derive(Serialize)]
 struct User {
     id: i32,
-    username: String
+    username: String,
 }
 
 #[test]
@@ -125,10 +137,10 @@ fn include_with_serializable_ref() {
 
     assert_json_include!(
         actual: &json!({
-            "id": 1,
-            "username": "bob",
-            "email": "bob@example.com"
-        }),
+             "id": 1,
+             "username": "bob",
+             "email": "bob@example.com"
+         }),
         expected: &user,
     );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,9 +1,8 @@
 use assert_json_diff::{
-    assert_json_eq, assert_json_eq_assume_float, assert_json_eq_no_panic, assert_json_include,
-    assert_json_include_assume_float, assert_json_include_no_panic, NumericMode,
+    assert_json_eq, assert_json_include, assert_json_matches, assert_json_matches_no_panic,
+    CompareMode, Config, NumericMode,
 };
 use serde::Serialize;
-
 use serde_json::json;
 
 #[test]
@@ -60,9 +59,10 @@ fn different_numeric_types_eq_should_fail() {
 fn different_numeric_types_assume_float() {
     let actual = json!({ "a": { "b": true }, "c": [true, null, 1] });
     let expected = json!({ "a": { "b": true }, "c": [true, null, 1.0] });
-    assert_json_include_assume_float!(actual: &actual, expected: &expected);
+    let config = Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat);
+    assert_json_matches!(&actual, &expected, config.clone());
 
-    assert_json_eq_assume_float!(actual, expected)
+    assert_json_matches!(actual, expected, config.compare_mode(CompareMode::Strict))
 }
 
 #[test]
@@ -78,31 +78,37 @@ fn can_fail_with_exact_match() {
 }
 
 #[test]
-fn inclusive_match_without_panicing() {
-    assert!(assert_json_include_no_panic(
+fn inclusive_match_without_panicking() {
+    assert!(assert_json_matches_no_panic(
         &json!({ "a": 1, "b": 2 }),
         &json!({ "b": 2}),
-        NumericMode::Strict
+        Config::new(CompareMode::Inclusive,).numeric_mode(NumericMode::Strict),
     )
     .is_ok());
 
-    assert!(assert_json_include_no_panic(
+    assert!(assert_json_matches_no_panic(
         &json!({ "a": 1, "b": 2 }),
         &json!("foo"),
-        NumericMode::Strict
+        Config::new(CompareMode::Inclusive,).numeric_mode(NumericMode::Strict),
     )
     .is_err());
 }
 
 #[test]
-fn exact_match_without_panicing() {
-    assert!(
-        assert_json_eq_no_panic(&json!([1, 2, 3]), &json!([1, 2, 3]), NumericMode::Strict).is_ok()
-    );
+fn exact_match_without_panicking() {
+    assert!(assert_json_matches_no_panic(
+        &json!([1, 2, 3]),
+        &json!([1, 2, 3]),
+        Config::new(CompareMode::Strict).numeric_mode(NumericMode::Strict)
+    )
+    .is_ok());
 
-    assert!(
-        assert_json_eq_no_panic(&json!([1, 2, 3]), &json!("foo"), NumericMode::Strict).is_err()
-    );
+    assert!(assert_json_matches_no_panic(
+        &json!([1, 2, 3]),
+        &json!("foo"),
+        Config::new(CompareMode::Strict).numeric_mode(NumericMode::Strict)
+    )
+    .is_err());
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
@kate-shine What do you think about this? The idea is that rather than adding `assert_json_include_assume_float` style macros for each config we instead allow something like this:

```rust
use assert_json_diff::{
    CompareMode,
    Config,
    NumericMode,
    assert_json_matches,
};
use serde_json::json;

let config = Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat);

assert_json_matches!(
    json!({
        "a": { "b": 1 },
    }),
    json!({
        "a": {},
    }),
    config,
)
```

This should allow us to add more configuration without having to add new macros.