### PR TITLE
Export diff module stuff

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,7 +3,7 @@ use crate::{CompareMode, Config, NumericMode};
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
-pub(crate) fn diff<'a>(lhs: &'a Value, rhs: &'a Value, config: Config) -> Vec<Difference<'a>> {
+pub fn diff<'a>(lhs: &'a Value, rhs: &'a Value, config: Config) -> Vec<Difference<'a>> {
     let mut acc = vec![];
     diff_with(lhs, rhs, config, Path::Root, &mut acc);
     acc
@@ -201,8 +201,8 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Difference<'a> {
-    path: Path<'a>,
+pub struct Difference<'a> {
+    pub path: Path<'a>,
     lhs: Option<&'a Value>,
     rhs: Option<&'a Value>,
     config: Config,
@@ -253,7 +253,7 @@ impl<'a> fmt::Display for Difference<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-enum Path<'a> {
+pub enum Path<'a> {
     Root,
     Keys(Vec<Key<'a>>),
 }
@@ -286,7 +286,7 @@ impl<'a> fmt::Display for Path<'a> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-enum Key<'a> {
+pub enum Key<'a> {
     Idx(usize),
     Field(&'a str),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ use diff::diff;
 use serde::Serialize;
 
 mod core_ext;
-mod diff;
+pub mod diff;
 
 /// Compare two JSON values for an inclusive match.
 ///


### PR DESCRIPTION
Hello, 

 at first, I would like to very thank you for this library, we used it for our tests and it works perfect.

And second, we have one use case: "we need to compare two jsons to be exact, but we need to ignore some properties".
So, I needed to make `diff` module public, because I ended up with this implementation, which works for us.
I am fine to depends on our fork, but I would better depends on your library.
What do you think?


It is inspired by your `assert_json_matches_no_panic`:

```
        if !ignore_json_properties.is_empty() {
            assert_json_eq_no_panic_with_ignore_json_properties(
                lhs,
                rhs,
                assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict),
                ignore_json_properties,
            )
        } else {
            assert_json_diff::assert_json_matches_no_panic(
                lhs,
                rhs,
                assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict),
            )
        }
```

 
```
fn assert_json_eq_no_panic_with_ignore_json_properties<Lhs, Rhs>(
        lhs: &Lhs,
        rhs: &Rhs,
        config: assert_json_diff::Config,
        ignore_json_properties: &[String],
    ) -> Result<(), String>
    where
        Lhs: Serialize,
        Rhs: Serialize,
    {
        let lhs = serde_json::to_value(lhs).unwrap_or_else(|err| {
            panic!(
                "Couldn't convert left hand side value to JSON. Serde error: {}",
                err
            )
        });
        let rhs = serde_json::to_value(rhs).unwrap_or_else(|err| {
            panic!(
                "Couldn't convert right hand side value to JSON. Serde error: {}",
                err
            )
        });

        let diffs = assert_json_diff::diff::diff(&lhs, &rhs, config);

        if diffs.is_empty() {
            Ok(())
        } else {
            let diffs = diffs
                .into_iter()
                .filter(|diff| {
                    if let assert_json_diff::diff::Path::Keys(keys) = &diff.path {
                        if let Some(last_key) = keys.last() {
                            let ignore = ignore_json_properties.iter().any(|ijp| {
                                if let assert_json_diff::diff::Key::Field(field_name) = last_key {
                                    field_name.eq(ijp)
                                } else {
                                    false
                                }
                            });
                            if ignore {
                                println!();
                                println!(
                                    "Found IGNORED property, which does not matches, diff: {:?}",
                                    diff
                                );
                                false
                            } else {
                                true
                            }
                        } else {
                            true
                        }
                    } else {
                        true
                    }
                })
                .collect::<Vec<_>>();

            if diffs.is_empty() {
                Ok(())
            } else {
                let msg = diffs
                    .into_iter()
                    .map(|d| d.to_string())
                    .collect::<Vec<_>>()
                    .join("\n\n");
                Err(msg)
            }
        }
    }
```
