### PR TITLE
Don't move the `Value`s being compared in `assert_json_matches`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,9 +252,7 @@ macro_rules! assert_json_eq {
 #[macro_export]
 macro_rules! assert_json_matches {
     ($lhs:expr, $rhs:expr, $config:expr $(,)?) => {{
-        let lhs = $lhs;
-        let rhs = $rhs;
-        if let Err(error) = $crate::assert_json_matches_no_panic(&lhs, &rhs, $config) {
+        if let Err(error) = $crate::assert_json_matches_no_panic(&$lhs, &$rhs, $config) {
             panic!("\n\n{}\n\n", error);
         }
     }};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -60,7 +60,7 @@ fn different_numeric_types_assume_float() {
     let actual = json!({ "a": { "b": true }, "c": [true, null, 1] });
     let expected = json!({ "a": { "b": true }, "c": [true, null, 1.0] });
     let config = Config::new(CompareMode::Inclusive).numeric_mode(NumericMode::AssumeFloat);
-    assert_json_matches!(&actual, &expected, config.clone());
+    assert_json_matches!(actual, expected, config.clone());
 
     assert_json_matches!(actual, expected, config.compare_mode(CompareMode::Strict))
 }


### PR DESCRIPTION
This avoids having to add references in front of each value, matching the
behavior of `std::assert_eq`.