### PR TITLE
fix clippy warnings

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -62,7 +62,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
         if !is_equal {
             self.acc.push(Difference {
                 lhs: Some(lhs),
-                rhs: Some(&self.rhs),
+                rhs: Some(self.rhs),
                 path: self.path.clone(),
                 config: self.config.clone(),
             });
@@ -83,7 +83,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                         } else {
                             self.acc.push(Difference {
                                 lhs: None,
-                                rhs: Some(&self.rhs),
+                                rhs: Some(self.rhs),
                                 path,
                                 config: self.config.clone(),
                             });
@@ -129,7 +129,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
         } else {
             self.acc.push(Difference {
                 lhs: Some(lhs),
-                rhs: Some(&self.rhs),
+                rhs: Some(self.rhs),
                 path: self.path.clone(),
                 config: self.config.clone(),
             });
@@ -150,7 +150,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
                         } else {
                             self.acc.push(Difference {
                                 lhs: None,
-                                rhs: Some(&self.rhs),
+                                rhs: Some(self.rhs),
                                 path,
                                 config: self.config.clone(),
                             });
@@ -192,7 +192,7 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
         } else {
             self.acc.push(Difference {
                 lhs: Some(lhs),
-                rhs: Some(&self.rhs),
+                rhs: Some(self.rhs),
                 path: self.path.clone(),
                 config: self.config.clone(),
             });


### PR DESCRIPTION
Warnings:
````
cargo clippy
    Checking assert-json-diff v2.0.1 (/Users/yannsimon/projects/rust/assert-json-diff)
warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/diff.rs:65:27
   |
65 |                 rhs: Some(&self.rhs),
   |                           ^^^^^^^^^ help: change this to: `self.rhs`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> src/diff.rs:86:43
   |
86 | ...                   rhs: Some(&self.rhs),
   |                                 ^^^^^^^^^ help: change this to: `self.rhs`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/diff.rs:132:27
    |
132 |                 rhs: Some(&self.rhs),
    |                           ^^^^^^^^^ help: change this to: `self.rhs`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/diff.rs:153:43
    |
153 | ...                   rhs: Some(&self.rhs),
    |                                 ^^^^^^^^^ help: change this to: `self.rhs`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/diff.rs:195:27
    |
195 |                 rhs: Some(&self.rhs),
    |                           ^^^^^^^^^ help: change this to: `self.rhs`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `assert-json-diff` (lib) generated 5 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.66s
```