### PR TITLE
Make the diff and Difference symbols public

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,7 +3,8 @@ use crate::{CompareMode, Config, NumericMode};
 use serde_json::Value;
 use std::{collections::HashSet, fmt};
 
-pub(crate) fn diff<'a>(lhs: &'a Value, rhs: &'a Value, config: Config) -> Vec<Difference<'a>> {
+/// Compare two json values and return a list of differences.
+pub fn diff<'a>(lhs: &'a Value, rhs: &'a Value, config: Config) -> Vec<Difference<'a>> {
     let mut acc = vec![];
     diff_with(lhs, rhs, config, Path::Root, &mut acc);
     acc
@@ -200,8 +201,9 @@ impl<'a, 'b> DiffFolder<'a, 'b> {
     }
 }
 
+/// A difference between two json values.
 #[derive(Debug, PartialEq)]
-pub(crate) struct Difference<'a> {
+pub struct Difference<'a> {
     path: Path<'a>,
     lhs: Option<&'a Value>,
     rhs: Option<&'a Value>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@
     unknown_lints
 )]
 
-use diff::diff;
+pub use diff::{diff, Difference};
 use serde::Serialize;
 
 mod core_ext;


### PR DESCRIPTION
This is by far the best diff crate for K/V in Rust apparently. Unfortunately I don't just want to assert and exit, so I would like to have access to the `Difference` primitive.
I appreciate that this crate was intentionally kept simple, but this would be a very welcome change for lack of better alternatives and not having to reinvent the wheel.